### PR TITLE
allow log entries url to be configured when setting up sink

### DIFF
--- a/src/Serilog.Sinks.Logentries/LoggerConfigurationLogentriesExtensions.cs
+++ b/src/Serilog.Sinks.Logentries/LoggerConfigurationLogentriesExtensions.cs
@@ -26,6 +26,9 @@ namespace Serilog
     public static class LoggerConfigurationLogentriesExtensions
     {
         const string DefaultLogentriesOutputTemplate = "{Timestamp:G} [{Level}] {Message}{NewLine}{Exception}";
+        
+        // Logentries API server address. 
+        const string LeApiUrl = "data.logentries.com";
 
         /// <summary>
         /// Adds a sink that writes log events to the Logentries.com webservice. 
@@ -40,6 +43,7 @@ namespace Serilog
         /// <param name="useSsl">Specify if the connection needs to be secured.</param>
         /// <param name="batchPostingLimit">The maximum number of events to post in a single batch.</param>
         /// <param name="period">The time to wait between checking for event batches.</param>
+        /// <param name="url">Url to logentries; this default to data.logentries.com</param>
         /// <returns>Logger configuration, allowing configuration to continue.</returns>
         /// <exception cref="ArgumentNullException">A required parameter is null.</exception>
         public static LoggerConfiguration Logentries(
@@ -49,7 +53,8 @@ namespace Serilog
             TimeSpan? period = null,
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
             string outputTemplate = DefaultLogentriesOutputTemplate,
-            IFormatProvider formatProvider = null)
+            IFormatProvider formatProvider = null,
+            string url = LeApiUrl)
         {
             if (loggerConfiguration == null) throw new ArgumentNullException("loggerConfiguration");
 
@@ -59,10 +64,10 @@ namespace Serilog
             var defaultedPeriod = period ?? LogentriesSink.DefaultPeriod;
 
             return loggerConfiguration.Sink(
-                new LogentriesSink(outputTemplate, formatProvider, token, useSsl, batchPostingLimit, defaultedPeriod),
+                new LogentriesSink(outputTemplate, formatProvider, token, useSsl, batchPostingLimit, defaultedPeriod, url),
                 restrictedToMinimumLevel);
         }
-         
+
         /// <summary>
         /// Adds a sink that writes log events to the Logentries.com webservice. 
         /// Create a token TCP input for this on the logentries website. 
@@ -74,6 +79,7 @@ namespace Serilog
         /// <param name="useSsl">Specify if the connection needs to be secured.</param>
         /// <param name="batchPostingLimit">The maximum number of events to post in a single batch.</param>
         /// <param name="period">The time to wait between checking for event batches.</param>
+        /// <param name="url">Url to logentries; this default to data.logentries.com</param>
         /// <returns>Logger configuration, allowing configuration to continue.</returns>
         /// <exception cref="ArgumentNullException">A required parameter is null.</exception>
         public static LoggerConfiguration Logentries(
@@ -83,7 +89,8 @@ namespace Serilog
             bool useSsl = true,
             int batchPostingLimit = LogentriesSink.DefaultBatchPostingLimit,
             TimeSpan? period = null,
-            LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum)
+            LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
+            string url = LeApiUrl)
         {
             if (loggerConfiguration == null) throw new ArgumentNullException("loggerConfiguration");
 
@@ -96,7 +103,7 @@ namespace Serilog
             var defaultedPeriod = period ?? LogentriesSink.DefaultPeriod;
 
             return loggerConfiguration.Sink(
-                new LogentriesSink(textFormatter, token, useSsl, batchPostingLimit, defaultedPeriod),
+                new LogentriesSink(textFormatter, token, useSsl, batchPostingLimit, defaultedPeriod, url),
                 restrictedToMinimumLevel);
         }
     }

--- a/src/Serilog.Sinks.Logentries/Sinks/Logentries/LeClient.cs
+++ b/src/Serilog.Sinks.Logentries/Sinks/Logentries/LeClient.cs
@@ -44,9 +44,6 @@ namespace Serilog.Sinks.Logentries
 {
     class LeClient
     {
-        // Logentries API server address. 
-        const String LeApiUrl = "data.logentries.com";
-
         // Port number for token logging on Logentries API server. 
         const int LeApiTokenPort = 80;
 
@@ -59,9 +56,10 @@ namespace Serilog.Sinks.Logentries
         // Port number for SSL HTTP PUT logging on Logentries API server. 
         const int LeApiHttpsPort = 443;
 
-        public LeClient(bool useHttpPut, bool useSsl)
+        public LeClient(bool useHttpPut, bool useSsl, string url)
         {
             m_UseSsl = useSsl;
+            _url = url;
             if (!m_UseSsl)
                 m_TcpPort = useHttpPut ? LeApiHttpPort : LeApiTokenPort;
             else
@@ -69,6 +67,7 @@ namespace Serilog.Sinks.Logentries
         }
 
         bool m_UseSsl;
+        private readonly string _url;
         int m_TcpPort;
         TcpClient m_Client;
         Stream m_Stream;
@@ -88,14 +87,14 @@ namespace Serilog.Sinks.Logentries
             {
                 NoDelay = true
             };
-            await m_Client.ConnectAsync(LeApiUrl, m_TcpPort).ConfigureAwait(false);
+            await m_Client.ConnectAsync(_url, m_TcpPort).ConfigureAwait(false);
 
             m_Stream = m_Client.GetStream();
 
             if (m_UseSsl)
             {
                 m_SslStream = new SslStream(m_Stream);
-                await m_SslStream.AuthenticateAsClientAsync(LeApiUrl).ConfigureAwait(false);
+                await m_SslStream.AuthenticateAsClientAsync(_url).ConfigureAwait(false);
             }
         }
 

--- a/src/Serilog.Sinks.Logentries/Sinks/Logentries/LogentriesSink.cs
+++ b/src/Serilog.Sinks.Logentries/Sinks/Logentries/LogentriesSink.cs
@@ -32,9 +32,10 @@ namespace Serilog.Sinks.Logentries
     {
         readonly string _token;
         readonly bool _useSsl;
+        private readonly string _url;
         LeClient _client;
         readonly ITextFormatter _textFormatter;
-
+        
         /// <summary>
         /// UTF-8 output character set.
         /// </summary>
@@ -61,8 +62,9 @@ namespace Serilog.Sinks.Logentries
         /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
         /// <param name="token">The input key as found on the Logentries website.</param>
         /// <param name="useSsl">Indicates if you want to use SSL or not.</param>
-        public LogentriesSink(string outputTemplate, IFormatProvider formatProvider, string token, bool useSsl, int batchPostingLimit, TimeSpan period)
-            : this(new MessageTemplateTextFormatter(outputTemplate, formatProvider), token, useSsl, batchPostingLimit, period)
+        /// <param name="url">Url to logentries</param>
+        public LogentriesSink(string outputTemplate, IFormatProvider formatProvider, string token, bool useSsl, int batchPostingLimit, TimeSpan period, string url)
+            : this(new MessageTemplateTextFormatter(outputTemplate, formatProvider), token, useSsl, batchPostingLimit, period, url)
         {
         }
 
@@ -74,12 +76,13 @@ namespace Serilog.Sinks.Logentries
         /// <param name="useSsl">Indicates if you want to use SSL or not.</param>
         /// <param name="batchPostingLimit">The maximum number of events to post in a single batch.</param>
         /// <param name="period">The time to wait between checking for event batches.</param>
-        public LogentriesSink(ITextFormatter textFormatter, string token, bool useSsl, int batchPostingLimit, TimeSpan period)
+        public LogentriesSink(ITextFormatter textFormatter, string token, bool useSsl, int batchPostingLimit, TimeSpan period, string url)
              : base(batchPostingLimit, period)
         {
             _textFormatter = textFormatter ?? throw new ArgumentNullException(nameof(textFormatter));
             _token = token;
             _useSsl = useSsl;
+            _url = url;
         }
 
         /// <summary>
@@ -96,7 +99,7 @@ namespace Serilog.Sinks.Logentries
                 await Task.FromResult(0);
 
             if (_client == null)
-                _client = new LeClient(false, _useSsl);
+                _client = new LeClient(false, _useSsl, _url);
 
             await _client.ConnectAsync().ConfigureAwait(false);
 


### PR DESCRIPTION
This resolves https://github.com/serilog/serilog-sinks-logentries/issues/28

The behavior is the same if the configurable url is not provided therefore backwards compatible.