### PR TITLE
Adds support for LogEntries DataHub local service

### DIFF
--- a/src/Serilog.Sinks.Logentries/LoggerConfigurationLogentriesExtensions.cs
+++ b/src/Serilog.Sinks.Logentries/LoggerConfigurationLogentriesExtensions.cs
@@ -30,6 +30,12 @@ namespace Serilog
         // Logentries API server address. 
         const string LeApiUrl = "data.logentries.com";
 
+        // Port number for token logging on Logentries API server. 
+        const int LeApiTokenPort = 80;
+
+        // Port number for TLS encrypted token logging on Logentries API server 
+        const int LeApiTokenTlsPort = 443;
+
         /// <summary>
         /// Adds a sink that writes log events to the Logentries.com webservice. 
         /// Create a token TCP input for this on the logentries website. 
@@ -48,7 +54,8 @@ namespace Serilog
         /// <exception cref="ArgumentNullException">A required parameter is null.</exception>
         public static LoggerConfiguration Logentries(
             this LoggerSinkConfiguration loggerConfiguration,
-             string token, bool useSsl = true,
+            string token,
+            bool useSsl = true,
             int batchPostingLimit = LogentriesSink.DefaultBatchPostingLimit,
             TimeSpan? period = null,
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
@@ -63,8 +70,14 @@ namespace Serilog
 
             var defaultedPeriod = period ?? LogentriesSink.DefaultPeriod;
 
+            int port;
+            if (!useSsl)
+                port = LeApiTokenPort;
+            else
+                port = LeApiTokenTlsPort;
+
             return loggerConfiguration.Sink(
-                new LogentriesSink(outputTemplate, formatProvider, token, useSsl, batchPostingLimit, defaultedPeriod, url),
+                new LogentriesSink(outputTemplate, formatProvider, token, useSsl, batchPostingLimit, defaultedPeriod, url, port),
                 restrictedToMinimumLevel);
         }
 
@@ -84,7 +97,7 @@ namespace Serilog
         /// <exception cref="ArgumentNullException">A required parameter is null.</exception>
         public static LoggerConfiguration Logentries(
             this LoggerSinkConfiguration loggerConfiguration,
-             string token, 
+            string token,
             ITextFormatter textFormatter,
             bool useSsl = true,
             int batchPostingLimit = LogentriesSink.DefaultBatchPostingLimit,
@@ -102,8 +115,87 @@ namespace Serilog
 
             var defaultedPeriod = period ?? LogentriesSink.DefaultPeriod;
 
+            int port;
+            if (!useSsl)
+                port = LeApiTokenPort;
+            else
+                port = LeApiTokenTlsPort;
+
             return loggerConfiguration.Sink(
-                new LogentriesSink(textFormatter, token, useSsl, batchPostingLimit, defaultedPeriod, url),
+                new LogentriesSink(textFormatter, token, useSsl, batchPostingLimit, defaultedPeriod, url, port),
+                restrictedToMinimumLevel);
+        }
+        /// <summary>
+        /// Adds a sink that writes log events to the LogEntries DataHub local service. 
+        /// </summary>
+        /// <param name="loggerConfiguration">The logger configuration.</param>
+        /// <param name="restrictedToMinimumLevel">The minimum log event level required in order to write an event to the sink.</param>
+        /// <param name="dataHubServer">The local server name of the datahub service.</param>
+        /// <param name="dataHubPort">The port number for the local datahub service.</param>
+        /// <param name="outputTemplate">A message template describing the format used to write to the sink.
+        /// the default is "{Timestamp:G} [{Level}] {Message}{NewLine}{Exception}".</param>
+        /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
+        /// <param name="batchPostingLimit">The maximum number of events to post in a single batch.</param>
+        /// <param name="period">The time to wait between checking for event batches.</param>
+        /// <returns>Logger configuration, allowing configuration to continue.</returns>
+        /// <exception cref="ArgumentNullException">A required parameter is null.</exception>
+        public static LoggerConfiguration Logentries(
+            this LoggerSinkConfiguration loggerConfiguration,
+            string dataHubServer,
+            int dataHubPort,
+            int batchPostingLimit = LogentriesSink.DefaultBatchPostingLimit,
+            TimeSpan? period = null,
+            LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
+            string outputTemplate = DefaultLogentriesOutputTemplate,
+            IFormatProvider formatProvider = null)
+        {
+            if (loggerConfiguration == null)
+                throw new ArgumentNullException(nameof(loggerConfiguration));
+
+            if (string.IsNullOrWhiteSpace(dataHubServer))
+                throw new ArgumentNullException(nameof(dataHubServer));
+
+            var defaultedPeriod = period ?? LogentriesSink.DefaultPeriod;
+
+            return loggerConfiguration.Sink(
+                new LogentriesSink(outputTemplate, formatProvider, token: null, useSsl: false, batchPostingLimit, defaultedPeriod, dataHubServer, dataHubPort),
+                restrictedToMinimumLevel);
+        }
+
+        /// <summary>
+        /// Adds a sink that writes log events to the LogEntries DataHub local service. 
+        /// </summary>
+        /// <param name="loggerConfiguration">The logger configuration.</param>
+        /// <param name="dataHubServer">The local server name of the datahub service.</param>
+        /// <param name="dataHubPort">The port number for the local datahub service.</param>
+        /// <param name="restrictedToMinimumLevel">The minimum log event level required in order to write an event to the sink.</param>
+        /// <param name="textFormatter">Used to format the logs sent to Logentries.</param>
+        /// <param name="batchPostingLimit">The maximum number of events to post in a single batch.</param>
+        /// <param name="period">The time to wait between checking for event batches.</param>
+        /// <returns>Logger configuration, allowing configuration to continue.</returns>
+        /// <exception cref="ArgumentNullException">A required parameter is null.</exception>
+        public static LoggerConfiguration Logentries(
+            this LoggerSinkConfiguration loggerConfiguration,
+            string dataHubServer,
+            int dataHubPort,
+            ITextFormatter textFormatter,
+            int batchPostingLimit = LogentriesSink.DefaultBatchPostingLimit,
+            TimeSpan? period = null,
+            LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum)
+        {
+            if (loggerConfiguration == null)
+                throw new ArgumentNullException(nameof(loggerConfiguration));
+
+            if (string.IsNullOrWhiteSpace(dataHubServer))
+                throw new ArgumentNullException(nameof(dataHubServer));
+
+            if (textFormatter == null)
+                throw new ArgumentNullException(nameof(textFormatter));
+
+            var defaultedPeriod = period ?? LogentriesSink.DefaultPeriod;
+
+            return loggerConfiguration.Sink(
+                new LogentriesSink(textFormatter, token: null, useSsl: false, batchPostingLimit, defaultedPeriod, dataHubServer, dataHubPort),
                 restrictedToMinimumLevel);
         }
     }

--- a/src/Serilog.Sinks.Logentries/Sinks/Logentries/LeClient.cs
+++ b/src/Serilog.Sinks.Logentries/Sinks/Logentries/LeClient.cs
@@ -44,26 +44,11 @@ namespace Serilog.Sinks.Logentries
 {
     class LeClient
     {
-        // Port number for token logging on Logentries API server. 
-        const int LeApiTokenPort = 80;
-
-        // Port number for TLS encrypted token logging on Logentries API server 
-        const int LeApiTokenTlsPort = 443;
-
-        // Port number for HTTP PUT logging on Logentries API server. 
-        const int LeApiHttpPort = 80;
-
-        // Port number for SSL HTTP PUT logging on Logentries API server. 
-        const int LeApiHttpsPort = 443;
-
-        public LeClient(bool useHttpPut, bool useSsl, string url)
+        public LeClient(bool useHttpPut, bool useSsl, string url, int port)
         {
             m_UseSsl = useSsl;
             _url = url;
-            if (!m_UseSsl)
-                m_TcpPort = useHttpPut ? LeApiHttpPort : LeApiTokenPort;
-            else
-                m_TcpPort = useHttpPut ? LeApiHttpsPort : LeApiTokenTlsPort;
+            m_TcpPort = port;
         }
 
         bool m_UseSsl;

--- a/src/Serilog.Sinks.Logentries/Sinks/Logentries/LogentriesSink.cs
+++ b/src/Serilog.Sinks.Logentries/Sinks/Logentries/LogentriesSink.cs
@@ -33,6 +33,7 @@ namespace Serilog.Sinks.Logentries
         readonly string _token;
         readonly bool _useSsl;
         private readonly string _url;
+        private readonly int _port;
         LeClient _client;
         readonly ITextFormatter _textFormatter;
         
@@ -63,8 +64,9 @@ namespace Serilog.Sinks.Logentries
         /// <param name="token">The input key as found on the Logentries website.</param>
         /// <param name="useSsl">Indicates if you want to use SSL or not.</param>
         /// <param name="url">Url to logentries</param>
-        public LogentriesSink(string outputTemplate, IFormatProvider formatProvider, string token, bool useSsl, int batchPostingLimit, TimeSpan period, string url)
-            : this(new MessageTemplateTextFormatter(outputTemplate, formatProvider), token, useSsl, batchPostingLimit, period, url)
+        /// <param name="port">Port to logentries</param>
+        public LogentriesSink(string outputTemplate, IFormatProvider formatProvider, string token, bool useSsl, int batchPostingLimit, TimeSpan period, string url, int port)
+            : this(new MessageTemplateTextFormatter(outputTemplate, formatProvider), token, useSsl, batchPostingLimit, period, url, port)
         {
         }
 
@@ -76,13 +78,14 @@ namespace Serilog.Sinks.Logentries
         /// <param name="useSsl">Indicates if you want to use SSL or not.</param>
         /// <param name="batchPostingLimit">The maximum number of events to post in a single batch.</param>
         /// <param name="period">The time to wait between checking for event batches.</param>
-        public LogentriesSink(ITextFormatter textFormatter, string token, bool useSsl, int batchPostingLimit, TimeSpan period, string url)
+        public LogentriesSink(ITextFormatter textFormatter, string token, bool useSsl, int batchPostingLimit, TimeSpan period, string url, int port)
              : base(batchPostingLimit, period)
         {
             _textFormatter = textFormatter ?? throw new ArgumentNullException(nameof(textFormatter));
             _token = token;
             _useSsl = useSsl;
             _url = url;
+            _port = port;
         }
 
         /// <summary>
@@ -99,7 +102,9 @@ namespace Serilog.Sinks.Logentries
                 await Task.FromResult(0);
 
             if (_client == null)
-                _client = new LeClient(false, _useSsl, _url);
+            {
+                _client = new LeClient(false, _useSsl, _url, _port);
+            }
 
             await _client.ConnectAsync().ConfigureAwait(false);
 


### PR DESCRIPTION
This is backward compatible, but because of the requirement for token (which isn't used in datahub), I had to make two new configuration entry points. I also had to move port higher up, so it could be set from the configuration.

Let me know if you have any suggestions.


This resolves #31 